### PR TITLE
Fix SQLAlchemy ambiguous join in find_available_materials

### DIFF
--- a/spoolman/database/spool.py
+++ b/spoolman/database/spool.py
@@ -458,6 +458,7 @@ async def find_available_materials(
     stmt = (
         sqlalchemy.select(models.Filament.material)
         .distinct()
+        .select_from(models.Spool)
         .join(models.Filament, models.Spool.filament_id == models.Filament.id)
         .where(
             sqlalchemy.or_(


### PR DESCRIPTION
## Problem

The `/api/v1/spool/materials/available` endpoint fails with:

```
sqlalchemy.exc.InvalidRequestError: Don't know how to join to <Mapper at ...; Filament>.
Please use the .select_from() method to establish an explicit left side...
```

This was introduced in #3.

## Root Cause

The query in `find_available_materials` selects `Filament.material`, which makes SQLAlchemy infer `Filament` as the FROM table. The subsequent `.join(Filament, ...)` then fails because SQLAlchemy can't resolve an ambiguous self-join.

## Fix

Add `.select_from(models.Spool)` to explicitly establish `Spool` as the left side of the join.

## Testing

- Unit tests pass locally
- Linting passes