### PR TITLE
Install client_v2 deps in the release style job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4.0.3
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Bump version
         run: |
@@ -83,7 +83,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4.0.3
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -101,6 +101,13 @@ jobs:
       - name: Install client dependencies
         run: |
           cd client
+          npm ci
+
+      # lefthook's `ci` hook lints/formats/type-checks and unit-tests client_v2 too,
+      # via hardcoded ./node_modules/.bin/* paths, so its deps must be present.
+      - name: Install client_v2 dependencies
+        run: |
+          cd client_v2
           npm ci
 
       - name: Run pre-commit


### PR DESCRIPTION
Fixes the release pipeline, which fails at `style` → `Run pre-commit`:

```
Run lint check on client_v2 files   ❯ sh: 1: ./node_modules/.bin/eslint: not found
Run format check on client_v2 files ❯ sh: 1: ./node_modules/.bin/prettier: not found
Run type check on client_v2 files   ❯ sh: 1: paraglide-js: not found
Run unit tests on client_v2 files   ❯ sh: 1: ./node_modules/.bin/vitest: not found
```

## Cause

The upstream merge (#5) added client_v2 jobs to lefthook's `ci` hook. They run hardcoded `./node_modules/.bin/*` paths rooted at `client_v2/`, so that directory's dependencies have to be installed for the hook to work.

Upstream's `ci.yml` handles this with a dedicated step:

```yaml
# lefthook's ci hook lints/formats/type-checks client_v2 too, via
# hardcoded ./node_modules/.bin/* paths, so its deps must be present.
- name: Install client_v2 dependencies
```

`release.yml` is ours and never got it — it installs only the legacy client's deps, so every client_v2 check failed on a missing binary. CI passed on the same commit precisely because it has the step.

This is the second instance of the same gap: #5 already had to add the client_v2 **build** to `release.yml`'s `build-client` job. Because the release workflow is fork-owned, nothing upstream updates it when client_v2 grows a new requirement — worth remembering on the next sync.

## Changes

- **`style`**: install `client_v2` deps before running the lefthook hook.
- **`style` and `bump-version`**: node 20 → 24, matching `ci.yml`. Both run npm against client_v2 — `style` via the lefthook checks, `bump-version` via `poe bump`, which refreshes both clients' lock files — and client_v2's toolchain (vite 8, eslint 10) targets modern node. Using npm 10 there while the rest of the pipeline uses npm 11 also risks lockfile churn on release commits.

## Audit

Rather than patch just the failing step, I compared every job in `release.yml` against `ci.yml`:

| Job | Needs client_v2 | Status |
|---|---|---|
| `bump-version` | via `poe bump` | node aligned |
| `style` | yes | **fixed here** |
| `build-client` | yes | already handled (#5) |
| `build-amd64` / `build-arm64` / `publish-images` | yes (artifact download) | already handled (#5) |
| `build-tester` / `test` / `publish-release` | no | matches `ci.yml` |

So this should be the last gap of this kind. YAML validated.

## Verification

The real proof is a green release run — worth re-running the release once this lands, since the failure only reproduces there (CI passes on the same commit).
