### PR TITLE
Restore the label preset migration lost by PR #6's stacked merge

### DIFF
--- a/client_v2/src/lib/labels/migrateV1.test.ts
+++ b/client_v2/src/lib/labels/migrateV1.test.ts
@@ -1,5 +1,19 @@
-import { describe, expect, it } from 'vitest';
-import { migrateTemplate, presetToDesign } from './migrateV1';
+import { describe, expect, it, vi } from 'vitest';
+import { importV1Presets, migrateTemplate, presetToDesign } from './migrateV1';
+import { DEFAULT_LAYOUT } from './types';
+
+// The settings importV1Presets reads, stubbed per-test by the mocked getJson.
+const settings = vi.hoisted(() => ({ store: {} as Record<string, unknown[]> }));
+
+vi.mock('$lib/api/http', () => ({
+	getJson: vi.fn(async (path: string) => {
+		const key = path.replace('/setting/', '');
+		const presets = settings.store[key];
+		// Match the real server: an unregistered key 404s rather than replying.
+		if (presets === undefined) throw new Error(`404 ${key}`);
+		return { value: JSON.stringify(presets), is_set: true, type: 'array' };
+	})
+}));
 
 // migrateV1 rewrites label templates and print presets that users authored in the
 // v1 client. It runs unattended at first load and its output is what they see in
@@ -74,6 +88,50 @@ describe('migrateTemplate', () => {
 	it('does not rewrite a v1 path that is only a prefix of a token', () => {
 		// `{id}` must not match inside `{identifier}`.
 		expect(migrateTemplate('{identifier}')).toBe('{identifier}');
+	});
+
+	// The fork's filament presets root their paths at the filament, so the same
+	// bare token means a different field than it does in a spool preset. Getting
+	// this wrong would silently point a filament label at spool fields that don't
+	// exist for it.
+	describe('filament presets', () => {
+		it('roots bare paths at the filament, not the spool', () => {
+			expect(migrateTemplate('{id}', 'filament')).toBe('{filament.id}');
+			expect(migrateTemplate('{name}', 'filament')).toBe('{filament.name}');
+			expect(migrateTemplate('{material}', 'filament')).toBe('{filament.material}');
+		});
+
+		it('rewrites snake_case fields to camelCase', () => {
+			expect(migrateTemplate('{settings_extruder_temp}', 'filament')).toBe('{filament.nozzleTemp}');
+			expect(migrateTemplate('{spool_weight}', 'filament')).toBe('{filament.spoolWeight}');
+			expect(migrateTemplate('{article_number}', 'filament')).toBe('{filament.articleNumber}');
+		});
+
+		it('leaves vendor paths alone, since v1 filament presets already used vendor.*', () => {
+			expect(migrateTemplate('{vendor.name}', 'filament')).toBe('{vendor.name}');
+			expect(migrateTemplate('{vendor.comment}', 'filament')).toBe('{vendor.comment}');
+			expect(migrateTemplate('{vendor.empty_spool_weight}', 'filament')).toBe('{vendor.emptyWeight}');
+		});
+
+		it("treats extras as the filament's own", () => {
+			expect(migrateTemplate('{extra.foo}', 'filament')).toBe('{filament.extra.foo}');
+			expect(migrateTemplate('{vendor.extra.bar}', 'filament')).toBe('{vendor.extra.bar}');
+		});
+
+		it('rewrites inside the wrapped form and preserves literals', () => {
+			expect(migrateTemplate('{Article: {article_number}}', 'filament')).toBe(
+				'{Article: {filament.articleNumber}}'
+			);
+			expect(migrateTemplate('**{vendor.name} - {name}\n#{id}**', 'filament')).toBe(
+				'**{vendor.name} - {filament.name}\n#{filament.id}**'
+			);
+		});
+
+		it('does not apply the spool mapping', () => {
+			// `lot_nr` is a spool-only field; a filament preset has no spool, so it
+			// must not be rewritten into one.
+			expect(migrateTemplate('{lot_nr}', 'filament')).toBe('{lot_nr}');
+		});
 	});
 });
 
@@ -184,7 +242,146 @@ describe('presetToDesign', () => {
 		expect(presetToDesign({ labelSettings: { printSettings: { name: '' } } }).name).toBe('Imported label');
 	});
 
-	it('always produces a spool design, since v1 only printed spool labels', () => {
-		expect(presetToDesign({}).kind).toBe('spool');
+	it('defaults to a sheet-printed spool design, matching upstream v1', () => {
+		const d = presetToDesign({});
+		expect(d.kind).toBe('spool');
+		expect(d.layout.mode).toBe('sheet');
+	});
+
+	// The fork's v1 added filament labels and a file-export mode, each stored in
+	// its own setting. The source decides both, and the QR target follows the kind.
+	describe('fork preset sources', () => {
+		it('carries the kind and mode from the source setting', () => {
+			const d = presetToDesign({}, { kind: 'filament', mode: 'image' });
+			expect(d.kind).toBe('filament');
+			expect(d.layout.mode).toBe('image');
+		});
+
+		it('uses the filament default template for a filament preset', () => {
+			const d = presetToDesign({}, { kind: 'filament', mode: 'sheet' });
+			const text = d.elements.find((e) => e.type === 'text');
+			if (text?.type !== 'text') throw new Error('expected a text element');
+			// Already migrated, and rooted at the filament rather than a spool.
+			expect(text.template).toContain('{filament.name}');
+			expect(text.template).toContain('#{filament.id}');
+			expect(text.template).not.toContain('{spool.');
+		});
+
+		it('carries the export DPI and format across', () => {
+			const { layout } = presetToDesign(
+				{ labelSettings: { printSettings: { exportDpi: 203, exportFormat: 'aml' } } },
+				{ kind: 'spool', mode: 'image' }
+			);
+			expect(layout.dpi).toBe(203);
+			expect(layout.exportFormat).toBe('aml');
+		});
+
+		it('falls back to the defaults when the preset stored neither', () => {
+			const { layout } = presetToDesign({});
+			expect(layout.dpi).toBe(DEFAULT_LAYOUT.dpi);
+			expect(layout.exportFormat).toBe(DEFAULT_LAYOUT.exportFormat);
+		});
+
+		it('clamps an out-of-range DPI rather than trusting it', () => {
+			const dpi = (exportDpi: number) =>
+				presetToDesign({ labelSettings: { printSettings: { exportDpi } } }).layout.dpi;
+			expect(dpi(10)).toBe(96);
+			expect(dpi(5000)).toBe(600);
+			expect(dpi(203.4)).toBe(203);
+		});
+
+		it('falls back to PNG for a format this build does not know', () => {
+			const { layout } = presetToDesign({
+				// A hand-edited or newer-client value.
+				labelSettings: { printSettings: { exportFormat: 'svg' as 'png' } }
+			});
+			expect(layout.exportFormat).toBe('png');
+		});
+
+		it('prefers the stored AML label size over the size implied by the grid', () => {
+			const d = presetToDesign(
+				{
+					labelSettings: {
+						printSettings: { amlLabelSize: { width: 50, height: 25 }, columns: 3, rows: 8 }
+					}
+				},
+				{ kind: 'spool', mode: 'image' }
+			);
+			expect(d.label).toEqual({ w: 50, h: 25 });
+		});
+
+		it('ignores a degenerate stored AML size and derives one instead', () => {
+			const d = presetToDesign({
+				labelSettings: { printSettings: { amlLabelSize: { width: 0, height: 0 } } }
+			});
+			expect(d.label.w).toBeGreaterThan(0);
+			expect(d.label.h).toBeGreaterThan(0);
+		});
+	});
+});
+
+// importV1Presets is what actually runs on a real upgrade. Upstream stored only
+// `print_presets`; this fork added three more, and losing any of them silently
+// costs the user work they can't recover.
+describe('importV1Presets', () => {
+	const preset = (name: string, printSettings: Record<string, unknown> = {}) => ({
+		labelSettings: { printSettings: { name, ...printSettings } }
+	});
+
+	it('imports all four v1 preset settings, tagged with the right kind and mode', async () => {
+		settings.store = {
+			print_presets: [preset('spool sheet')],
+			print_presets_filament: [preset('filament sheet')],
+			image_presets: [preset('spool image')],
+			image_presets_filament: [preset('filament image')]
+		};
+		const designs = await importV1Presets();
+		expect(designs.map((d) => [d.name, d.kind, d.layout.mode])).toEqual([
+			['spool sheet', 'spool', 'sheet'],
+			['filament sheet', 'filament', 'sheet'],
+			['spool image', 'spool', 'image'],
+			['filament image', 'filament', 'image']
+		]);
+	});
+
+	it('still imports upstream presets when the fork-only settings are absent', async () => {
+		// An instance upgraded from upstream Spoolman has only this one key; the
+		// others 404 and must not abort the import.
+		settings.store = { print_presets: [preset('only one')] };
+		const designs = await importV1Presets();
+		expect(designs).toHaveLength(1);
+		expect(designs[0].name).toBe('only one');
+	});
+
+	it('returns nothing when v1 was never used', async () => {
+		settings.store = {};
+		expect(await importV1Presets()).toEqual([]);
+	});
+
+	it('gives every imported design a distinct id', async () => {
+		settings.store = {
+			print_presets: [preset('a'), preset('b')],
+			image_presets_filament: [preset('c')]
+		};
+		const ids = (await importV1Presets()).map((d) => d.id);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+
+	it('preserves the fork export settings end to end', async () => {
+		settings.store = {
+			image_presets_filament: [
+				preset('Filament AML', {
+					amlLabelSize: { width: 50, height: 25 },
+					exportDpi: 203,
+					exportFormat: 'aml'
+				})
+			]
+		};
+		const [d] = await importV1Presets();
+		expect(d.kind).toBe('filament');
+		expect(d.layout.mode).toBe('image');
+		expect(d.layout.exportFormat).toBe('aml');
+		expect(d.layout.dpi).toBe(203);
+		expect(d.label).toEqual({ w: 50, h: 25 });
 	});
 });

--- a/client_v2/src/lib/labels/migrateV1.ts
+++ b/client_v2/src/lib/labels/migrateV1.ts
@@ -1,20 +1,34 @@
 import { getJson } from '$lib/api/http';
 import { parseSetting, type SettingResponse } from '$lib/api/settings';
 import { paperSize } from './paper';
+import { resolveExportFormat } from './export';
 import {
 	DEFAULT_LAYOUT,
 	type LabelDesign,
 	type LabelElement,
+	type LabelKind,
 	type PaperName,
 	type PrintLayout
 } from './types';
 
-// One-time transfer of the v1 client's print presets (the `print_presets` server
-// setting) into v2 label designs. The v1 label was a fixed QR-left / text-right
-// layout with a text template; the v2 designer is far more capable, but the
-// default QR-code-plus-textbox design produced here reproduces the old look. The
-// layout (paper, margins, spacing, columns, safe-zone, skip, copies, border) maps
-// essentially 1-1; the template's field paths are rewritten to the v2 names.
+// One-time transfer of the v1 client's print presets into v2 label designs. The
+// v1 label was a fixed QR-left / text-right layout with a text template; the v2
+// designer is far more capable, but the default QR-code-plus-textbox design
+// produced here reproduces the old look. The layout (paper, margins, spacing,
+// columns, safe-zone, skip, copies, border) maps essentially 1-1; the template's
+// field paths are rewritten to the v2 names.
+//
+// Upstream v1 stored a single `print_presets` setting of spool labels printed to
+// a sheet. This fork added three more, so all four are imported:
+//
+//   print_presets           spool    → sheet   (upstream)
+//   print_presets_filament  filament → sheet
+//   image_presets           spool    → image   (file export)
+//   image_presets_filament  filament → image
+//
+// The fork's presets also carry settings upstream's v1 never had — an export DPI,
+// a PNG/AML format choice and an explicit AML label size — which map onto the v2
+// layout fields of the same meaning instead of falling back to the defaults.
 
 // --- v1 shapes (subset we read) --------------------------------------------
 // Mirrors client/src/pages/printing/printing.tsx.
@@ -31,6 +45,11 @@ interface V1PrintSettings {
 	paperSize?: string;
 	customPaperSize?: { width: number; height: number };
 	borderShowMode?: 'none' | 'border' | 'grid';
+	// Fork-only, set by the label export dialogs.
+	amlLabelSize?: { width: number; height: number };
+	exportDpi?: number;
+	exportFormat?: 'png' | 'aml';
+	exportAmlAsPages?: boolean;
 }
 interface V1LabelSettings {
 	showContent?: boolean;
@@ -54,6 +73,21 @@ Spool Weight: {filament.spool_weight} g
 {{comment}}
 {filament.comment}
 {filament.vendor.comment}`;
+
+// The fork's default template for *filament* presets, kept verbatim from
+// filamentQrCodePrintingDialog.tsx. A filament preset has no spool behind it, so
+// its paths are rooted at the filament itself — `{name}`, not `{filament.name}`.
+const V1_FILAMENT_DEFAULT_TEMPLATE = `**{vendor.name} - {name}
+#{id} - {material}**
+{Diameter: {diameter} mm}
+{Weight: {weight} g}
+{Spool Weight: {spool_weight} g}
+{ET: {settings_extruder_temp} °C}
+{BT: {settings_bed_temp} °C}
+{Article: {article_number}}
+{{comment}}
+{comment}
+{vendor.comment}`;
 
 // v1 placeholder path → v2 resolver path (see labels/template.ts). Paths already
 // identical in both (filament.name/material/price/density/diameter/weight/comment,
@@ -91,9 +125,46 @@ const PATH_MAP: Record<string, string> = {
 	'filament.vendor.registered': 'vendor.registered'
 };
 
+/**
+ * Filament-preset placeholder path → v2 resolver path. A filament preset's paths
+ * are rooted at the filament, so the bare names here mean something different
+ * from the same names in {@link PATH_MAP} (`{id}` is the filament, not the spool)
+ * — which is why the two kinds get separate maps rather than one merged one.
+ * Vendor paths were already `vendor.*` in v1 filament presets.
+ */
+const FILAMENT_PATH_MAP: Record<string, string> = {
+	id: 'filament.id',
+	name: 'filament.name',
+	material: 'filament.material',
+	diameter: 'filament.diameter',
+	density: 'filament.density',
+	weight: 'filament.weight',
+	price: 'filament.price',
+	comment: 'filament.comment',
+	registered: 'filament.registered',
+	spool_weight: 'filament.spoolWeight',
+	settings_extruder_temp: 'filament.nozzleTemp',
+	settings_bed_temp: 'filament.bedTemp',
+	color_hex: 'filament.color',
+	article_number: 'filament.articleNumber',
+	external_id: 'filament.externalId',
+	// Vendor
+	'vendor.empty_spool_weight': 'vendor.emptyWeight',
+	'vendor.external_id': 'vendor.externalId'
+};
+
 /** Rewrite a v1 template's `{path}` tokens to the v2 field paths. */
-export function migrateTemplate(template: string): string {
+export function migrateTemplate(template: string, kind: LabelKind = 'spool'): string {
 	let out = template;
+	if (kind === 'filament') {
+		// A filament preset's extras are the filament's own, and its vendor's are
+		// already `vendor.extra.*`. Only the bare form needs a prefix.
+		out = out.split('{extra.').join('{filament.extra.');
+		for (const [v1, v2] of Object.entries(FILAMENT_PATH_MAP)) {
+			out = out.split(`{${v1}}`).join(`{${v2}}`);
+		}
+		return out;
+	}
 	// Extra-field prefixes: v1 spool extras are bare `extra.*`; vendor extras are
 	// nested under filament. Do the longer vendor form first.
 	out = out.split('{filament.vendor.extra.').join('{vendor.extra.');
@@ -122,14 +193,16 @@ function mapPaper(ps: V1PrintSettings): { paper: PaperName; custom: { w: number;
 	return { paper: 'A4', custom };
 }
 
-function mapLayout(ps: V1PrintSettings): PrintLayout {
+function mapLayout(ps: V1PrintSettings, mode: PrintLayout['mode']): PrintLayout {
 	const { paper, custom } = mapPaper(ps);
 	return {
-		mode: 'sheet',
-		// v1 had no DPI setting and could only export PNG, so migrated designs start
-		// at the defaults for both.
-		dpi: DEFAULT_LAYOUT.dpi,
-		exportFormat: DEFAULT_LAYOUT.exportFormat,
+		mode,
+		// Upstream's v1 had neither setting, so a preset without them keeps the
+		// defaults. The fork's export dialogs wrote both, and they carry the same
+		// meaning in v2, so they come across as-is. A nonsensical stored DPI is
+		// clamped rather than dropped: it still tells us the intended ballpark.
+		dpi: clampDpi(ps.exportDpi),
+		exportFormat: resolveExportFormat(ps.exportFormat).id,
 		paper,
 		custom,
 		landscape: false,
@@ -155,11 +228,29 @@ function mapLayout(ps: V1PrintSettings): PrintLayout {
 }
 
 /**
+ * Keep a stored export DPI inside a range the rasterizer can actually honour.
+ * The fork's slider offered 96–600; anything outside that (hand-edited, or absent)
+ * falls back to the v2 default rather than producing a 1-pixel or 20-megapixel label.
+ */
+function clampDpi(dpi: number | undefined): number {
+	if (typeof dpi !== 'number' || !Number.isFinite(dpi)) return DEFAULT_LAYOUT.dpi;
+	return Math.min(600, Math.max(96, Math.round(dpi)));
+}
+
+/**
  * Recreate the v1 label size, which was derived from the grid rather than stored:
  * the usable area split into columns × rows, minus the spacing. Guarded so a
  * degenerate preset can't produce a zero/negative canvas.
+ *
+ * The fork's export presets are the exception: they stored the physical label size
+ * outright (it is what the AML file declares to the printer), so when that is
+ * present it wins over anything the sheet grid implies.
  */
 function deriveLabelSize(ps: V1PrintSettings, layout: PrintLayout): { w: number; h: number } {
+	const aml = ps.amlLabelSize;
+	if (aml && aml.width > 0 && aml.height > 0) {
+		return { w: aml.width, h: aml.height };
+	}
 	const page = paperSize(layout);
 	const cols = layout.columns;
 	const rows = Math.max(1, Math.round(ps.rows ?? 8));
@@ -225,20 +316,29 @@ function uid(): string {
 	return `v1-${Date.now()}-${counter++}`;
 }
 
+/** Which entity a v1 preset labelled, and how it was output. */
+export interface V1PresetSource {
+	kind: LabelKind;
+	mode: PrintLayout['mode'];
+}
+
 /** Convert a single v1 preset into a v2 design. */
-export function presetToDesign(preset: V1Preset): LabelDesign {
+export function presetToDesign(
+	preset: V1Preset,
+	source: V1PresetSource = { kind: 'spool', mode: 'sheet' }
+): LabelDesign {
 	const id = uid();
 	const ls = preset.labelSettings ?? {};
 	const ps = ls.printSettings ?? {};
-	const layout = mapLayout(ps);
+	const layout = mapLayout(ps, source.mode);
 	const label = deriveLabelSize(ps, layout);
-	const template = migrateTemplate(preset.template ?? V1_DEFAULT_TEMPLATE);
+	const fallback = source.kind === 'filament' ? V1_FILAMENT_DEFAULT_TEMPLATE : V1_DEFAULT_TEMPLATE;
+	const template = migrateTemplate(preset.template ?? fallback, source.kind);
 
 	return {
 		id,
 		name: ps.name || 'Imported label',
-		// v1 only ever printed spool labels.
-		kind: 'spool',
+		kind: source.kind,
 		label,
 		elements: buildElements(ls, id, label, template),
 		layout
@@ -246,19 +346,41 @@ export function presetToDesign(preset: V1Preset): LabelDesign {
 }
 
 /**
- * Read the v1 `print_presets` setting and convert it to v2 designs. Returns an
+ * The v1 settings holding print presets, and what each one's presets describe.
+ * Upstream shipped only `print_presets`; the rest are this fork's. Order fixes the
+ * order of the imported designs.
+ */
+const V1_PRESET_SETTINGS: { key: string; source: V1PresetSource }[] = [
+	{ key: 'print_presets', source: { kind: 'spool', mode: 'sheet' } },
+	{ key: 'print_presets_filament', source: { kind: 'filament', mode: 'sheet' } },
+	{ key: 'image_presets', source: { kind: 'spool', mode: 'image' } },
+	{ key: 'image_presets_filament', source: { kind: 'filament', mode: 'image' } }
+];
+
+/** Read one v1 preset setting. Returns [] when unset, empty or unreadable. */
+async function readPresetSetting(key: string, source: V1PresetSource): Promise<LabelDesign[]> {
+	try {
+		const s = await getJson<SettingResponse>(`/setting/${key}`);
+		if (!s?.is_set) return [];
+		const presets = parseSetting<V1Preset[]>(s, []);
+		if (!Array.isArray(presets) || presets.length === 0) return [];
+		return presets.map((p) => presetToDesign(p, source));
+	} catch (e) {
+		// A key this server doesn't know (an upstream server has none of the fork's
+		// three) 404s. That is the normal case, not a failure worth surfacing.
+		console.debug(`No v1 presets imported from ${key}`, e);
+		return [];
+	}
+}
+
+/**
+ * Read every v1 print-preset setting and convert them to v2 designs. Returns an
  * empty array when v1 was never used or on any error — this runs unattended at
  * first load and must never throw.
  */
 export async function importV1Presets(): Promise<LabelDesign[]> {
-	try {
-		const s = await getJson<SettingResponse>('/setting/print_presets');
-		if (!s?.is_set) return [];
-		const presets = parseSetting<V1Preset[]>(s, []);
-		if (!Array.isArray(presets) || presets.length === 0) return [];
-		return presets.map(presetToDesign);
-	} catch (e) {
-		console.error('Failed to import v1 print presets', e);
-		return [];
-	}
+	const groups = await Promise.all(
+		V1_PRESET_SETTINGS.map(({ key, source }) => readPresetSetting(key, source))
+	);
+	return groups.flat();
 }


### PR DESCRIPTION
Restores the work from #6, which never reached `master`.

## What happened

#6 was stacked on #5's branch (`jpapiez-didactic-adventure`). The two merges landed 17 seconds apart:

| PR | Base | Merged |
|---|---|---|
| #5 | `master` | 17:26:**09** |
| #6 | `jpapiez-didactic-adventure` | 17:26:**26** |

GitHub normally retargets a stacked PR onto `master` when its base branch merges. Here #5 was **squash**-merged, so its branch was never recorded as merged into master, and #6 quietly landed on a branch that had already served its purpose. GitHub reports #6 as MERGED — and it was, just into the orphaned branch rather than `master`.

Deleting the merged branches during cleanup then removed the only ref pointing at it. Nothing was lost — the commit still existed locally and is cherry-picked here unchanged.

Caught while validating the sync in #10: `client_v2` reported 253 tests where I expected 272, and `migrateV1.ts` had no trace of the fork's preset keys.

## What this restores

Upstream's v1→v2 label migration reads only `print_presets`, hardcodes spool/sheet, and defaults DPI and format — correct for upstream's v1, wrong for this fork's, which added filament labels, file export, a DPI control and AML output across four settings.

Without this, anyone upgrading keeps only their spool sheet presets, and even those lose their DPI and format; the other three settings are silently dropped.

- Imports all four preset settings, each mapped to the kind and mode it described.
- Gives filament presets their own path map — their templates are filament-rooted, so a bare `{id}` means the filament, not the spool, and `{lot_nr}` has no meaning at all. Reusing the spool table would have quietly retargeted labels at fields a filament doesn't have.
- Carries `exportDpi` / `exportFormat` / `amlLabelSize` across, with guards: DPI clamped to the 96–600 the v1 slider offered, unknown format falls back to PNG, degenerate AML size ignored.
- Skips missing keys, so instances upgraded from upstream import exactly as before.

## Verification

- Cherry-picked cleanly onto current `master` (0 conflicts) — it does not collide with the client_v2 changes arriving in #10.
- `migrateV1` tests: **44 passed**.
- `eslint` on both changed files: clean.

Full rationale is in #6. Squash-merging this one is fine — it is ordinary content, not a merge commit.
