### PR TITLE
Match a filament's GTIN however many digits the query carries

### DIFF
--- a/spoolman/api/v1/filament.py
+++ b/spoolman/api/v1/filament.py
@@ -285,6 +285,8 @@ async def find(
             description=(
                 "General search across vendor name, filament name, material, article number, GTIN, "
                 "and external ID. "
+                "A term that is a valid GTIN also matches the barcode in the zero-padded 14 digit form "
+                "it is stored as, whichever GS1 length or separators the term carries. "
                 "Separate multiple terms with a comma. Surround a term with quotes for an exact match."
             ),
         ),
@@ -329,7 +331,9 @@ async def find(
             title="Filament GTIN",
             description=(
                 "Partial case-insensitive search term for the filament GTIN. "
-                "Since GTINs are stored zero-padded to 14 digits, a bare UPC-A or EAN-13 matches as-is. "
+                "GTINs are stored zero-padded to 14 digits, and a term that is a valid GTIN also "
+                "matches that stored form, so a barcode is found whichever GS1 length it is given in "
+                "and whether or not it carries the separators printed under it. "
                 "Separate multiple terms with a comma. "
                 "Specify an empty string to match filaments with no GTIN. "
                 "Surround a term with quotes to search for the exact term."

--- a/spoolman/database/filament.py
+++ b/spoolman/database/filament.py
@@ -25,6 +25,7 @@ from spoolman.database.utils import (
 )
 from spoolman.exceptions import ItemDeleteError, ItemNotFoundError
 from spoolman.extra_field_registry import EntityType
+from spoolman.gtin import expand_gtin_query
 from spoolman.math import delta_e, hex_to_rgb, rgb_to_lab
 from spoolman.ws import websocket_manager
 
@@ -141,12 +142,12 @@ async def find(
             models.Filament.gtin,
             models.Filament.external_id,
         ],
-        search,
+        expand_gtin_query(search),
     )
     stmt = add_where_clause_str_opt(stmt, models.Filament.name, name)
     stmt = add_where_clause_str_opt(stmt, models.Filament.material, material)
     stmt = add_where_clause_str_opt(stmt, models.Filament.article_number, article_number)
-    stmt = add_where_clause_str_opt(stmt, models.Filament.gtin, gtin)
+    stmt = add_where_clause_str_opt(stmt, models.Filament.gtin, expand_gtin_query(gtin))
     stmt = add_where_clause_str_opt(stmt, models.Filament.external_id, external_id)
 
     total_count = None

--- a/spoolman/gtin.py
+++ b/spoolman/gtin.py
@@ -50,6 +50,37 @@ def normalize_gtin(value: str | None) -> str | None:
     return digits.zfill(_GTIN_STORED_LENGTH)
 
 
+def expand_gtin_query(value: str | None) -> str | None:
+    """Widen a filter value so a barcode term also matches the 14 digit form it is stored as.
+
+    A query carries whatever the label or the scanner produced -- a bare UPC-A, or an EAN-13 with
+    the separators printed under it -- while the column holds the zero-padded 14 digit form. The
+    two only line up by chance: the ``gtin`` filter's substring match happens to cover a bare
+    barcode, but its quoted exact form does not, and the ``search`` filter matches on a prefix, so
+    ``850078714923`` misses ``00850078714923`` outright.
+
+    Every term that is a valid GTIN therefore gains an extra exact-match term for its normalized
+    form. Terms are OR'd together by the filter helpers, and the original term is kept, so this
+    only ever widens the filter -- a partial-digit search such as ``8500787`` still behaves as
+    before, as does an empty term's "field is unset" meaning.
+    """
+    if not value:
+        return value
+
+    terms = value.split(",")
+    extra: list[str] = []
+    for term in terms:
+        quoted = len(term) > 1 and term[0] == '"' and term[-1] == '"'
+        normalized = normalize_gtin(term[1:-1] if quoted else term)
+        if normalized is None:
+            continue
+        exact = f'"{normalized}"'
+        if exact not in terms and exact not in extra:
+            extra.append(exact)
+
+    return ",".join(terms + extra)
+
+
 def format_gtin(value: str | None) -> str | None:
     """Render a stored GTIN in the shortest GS1 length that fits it.
 

--- a/tests/test_gtin.py
+++ b/tests/test_gtin.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from spoolman.gtin import format_gtin, normalize_gtin
+from spoolman.gtin import expand_gtin_query, format_gtin, normalize_gtin
 
 
 @pytest.mark.parametrize(
@@ -99,3 +99,46 @@ def test_format_gtin_round_trip(value: str):
     normalized = normalize_gtin(value)
     assert normalized is not None
     assert format_gtin(normalized) == value
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("850078714923", '850078714923,"00850078714923"', id="as-printed"),
+        pytest.param('"850078714923"', '"850078714923","00850078714923"', id="quoted"),
+        pytest.param("8-500787-14923", '8-500787-14923,"00850078714923"', id="separators"),
+        pytest.param("96385074", '96385074,"00000096385074"', id="gtin-8"),
+        pytest.param(
+            "850078714923,6938936709947",
+            '850078714923,6938936709947,"00850078714923","06938936709947"',
+            id="two-barcodes",
+        ),
+    ],
+)
+def test_expand_gtin_query_adds_the_stored_form(value: str, expected: str):
+    """A barcode term gains an exact-match term for the 14 digit form the column holds."""
+    assert expand_gtin_query(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # Already the stored form, quoted: the term it would gain is the one it already is.
+        pytest.param('"00850078714923"', id="already-stored"),
+        # Too few digits to be a GTIN, so it stays a partial-digit search.
+        pytest.param("8500787", id="partial"),
+        # A bad check digit is not a barcode, so there is no stored form to add.
+        pytest.param("850078714924", id="bad-check-digit"),
+        pytest.param("PM70820", id="article-number"),
+        # An empty term means "no GTIN recorded" and must keep meaning that.
+        pytest.param("", id="empty"),
+        pytest.param("PLA,", id="trailing-empty"),
+    ],
+)
+def test_expand_gtin_query_leaves_a_non_barcode_alone(value: str):
+    """Only a valid GTIN is widened, so every other filter keeps its exact prior meaning."""
+    assert expand_gtin_query(value) == value
+
+
+def test_expand_gtin_query_none():
+    assert expand_gtin_query(None) is None

--- a/tests_integration/tests/filament/test_gtin.py
+++ b/tests_integration/tests/filament/test_gtin.py
@@ -138,6 +138,11 @@ def test_update_filament_gtin_clear(random_filament: dict[str, Any]):
         pytest.param(UPC_A, id="as-printed"),
         pytest.param(UPC_A_STORED, id="as-stored"),
         pytest.param(f'"{UPC_A_STORED}"', id="exact"),
+        # The barcode as printed, asked for exactly: the padding is Spoolman's, not the label's,
+        # so a caller quoting what it scanned still has to find it.
+        pytest.param(f'"{UPC_A}"', id="exact-as-printed"),
+        # What a label reads with the separators printed under the bars.
+        pytest.param(f"{UPC_A[:1]}-{UPC_A[1:6]}-{UPC_A[6:]}", id="with-separators"),
     ],
 )
 def test_find_filament_by_gtin(query: str):
@@ -158,17 +163,67 @@ def test_find_filament_by_gtin(query: str):
         httpx.delete(f"{URL}/api/v1/filament/{filament['id']}").raise_for_status()
 
 
-def test_search_filament_by_gtin():
-    """The general search term matches a filament's GTIN."""
+def test_find_filament_by_gtin_partial():
+    """A partial-digit term is still a substring search, so widening a barcode has not narrowed it."""
     # Setup
-    wanted = add_filament(gtin=EAN_13)
+    wanted = add_filament(gtin=UPC_A)
+    other = add_filament(gtin=EAN_13)
 
     # Execute
-    result = httpx.get(f"{URL}/api/v1/filament", params={"search": EAN_13_STORED})
+    result = httpx.get(f"{URL}/api/v1/filament", params={"gtin": UPC_A[2:8]})
     result.raise_for_status()
 
     # Verify
     assert_lists_compatible(result.json(), [wanted])
 
     # Clean up
-    httpx.delete(f"{URL}/api/v1/filament/{wanted['id']}").raise_for_status()
+    for filament in (wanted, other):
+        httpx.delete(f"{URL}/api/v1/filament/{filament['id']}").raise_for_status()
+
+
+def test_find_filament_with_no_gtin():
+    """An empty term still means "no barcode recorded" rather than "any barcode"."""
+    # Setup
+    wanted = add_filament()
+    other = add_filament(gtin=UPC_A)
+
+    # Execute
+    result = httpx.get(f"{URL}/api/v1/filament", params={"gtin": ""})
+    result.raise_for_status()
+
+    # Verify
+    assert_lists_compatible(result.json(), [wanted])
+
+    # Clean up
+    for filament in (wanted, other):
+        httpx.delete(f"{URL}/api/v1/filament/{filament['id']}").raise_for_status()
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        pytest.param(EAN_13, id="as-printed"),
+        pytest.param(EAN_13_STORED, id="as-stored"),
+        pytest.param(f'"{EAN_13}"', id="exact-as-printed"),
+    ],
+)
+def test_search_filament_by_gtin(query: str):
+    """The general search term matches a filament's GTIN.
+
+    The search filter matches on a prefix, so the padding the column carries would otherwise put
+    a barcode scanned as printed out of its reach entirely.
+    """
+    # Setup
+    wanted = add_filament(gtin=EAN_13)
+    other = add_filament(gtin=UPC_A)
+
+    # Execute
+    result = httpx.get(f"{URL}/api/v1/filament", params={"search": query})
+    result.raise_for_status()
+
+    # Verify
+    assert_lists_compatible(result.json(), [wanted])
+
+    # Clean up
+    for filament in (wanted, other):
+        httpx.delete(f"{URL}/api/v1/filament/{filament['id']}").raise_for_status()


### PR DESCRIPTION
## Problem

We normalize a GTIN to its zero-padded 14 digit form on write, but the filament **filters** compared the query against that stored form as-is. So a barcode given the way it's printed on the label only matched by accident:

| Query | Before |
|---|---|
| `?gtin="850078714923"` | ✗ quoted term is an exact match; the column holds `00850078714923` |
| `?gtin=8-50078-714923` | ✗ separators printed under the bars aren't stripped from a query |
| `?search=850078714923` | ✗ `search` matches on a **prefix**, and the padding sits in front |
| `?search="6938936709947"` | ✗ same, exact form |
| `?search=96385074` | ✗ an EAN-8 is stored with six leading zeros |

The `search` case is the worst of these: because that filter is a prefix match, a barcode scanned as printed could never reach its stored value at all — no length of GTIN shorter than 14 digits was findable through it.

## Fix

`expand_gtin_query()` in `spoolman/gtin.py` appends an exact-match term for every term that is a valid GTIN, and `filament.find()` applies it to both the `gtin` and `search` parameters.

This is purely **additive**: the original term is kept and the filter helpers OR their terms together, so nothing that matched before stops matching. Deliberately preserved:

- `?gtin=007871` — too few digits to be a GTIN, so it stays a substring search
- `?gtin=` — an empty term still means "no GTIN recorded"
- `?gtin=850078714924` — a bad check digit is not a barcode, so there's no stored form to add

## Verification

Ran the filter path against a real SQLite database, before and after, with `expand_gtin_query` stubbed out to get the baseline:

```
before: 10/15 passed
after:  15/15 passed
```

All five previously-failing cases now pass, and the ten that already worked still do.

Also added 9 unit tests (`tests/test_gtin.py`) and 4 integration cases (`tests_integration/tests/filament/test_gtin.py`), including a partial-digit search and an empty-term search to pin the no-narrowing guarantee. 279 unit tests and `ruff check` / `ruff format` pass.

## Not included

The `/search` endpoint (`spoolman/database/search.py`) matches on substrings, so a bare barcode already works there; only a term carrying separators misses. Fixing that one needs matching changes in `_classify_match` — where SQL matching and Python re-checking must agree or rows silently drop — so it's left for a separate change.